### PR TITLE
Add organization github profile url to organization card

### DIFF
--- a/components/OrganizationCard.vue
+++ b/components/OrganizationCard.vue
@@ -9,7 +9,19 @@
     <div class="block w-full pl-2 lg:px-3 mt-8 lg:mt-12">
       <div class="flex flex-col">
         <h3 class="full-name">{{ name }}</h3>
-        <p class="user-name">{{ username }}</p>
+        <div>
+          <a :href="profileUrl" target="_blank" class="username-container">
+            <img
+              class="h-5 pr-1"
+              src="~assets/images/footer/icon-github.svg"
+              alt="Github Account"
+              width="auto"
+              height="20"
+              loading="lazy"
+            />
+            {{ username }}</a
+          >
+        </div>
       </div>
     </div>
     <div class="self-center">
@@ -40,6 +52,7 @@ export default {
     repositoriesNumber: { type: Number, default: 0 },
     repositoriesStars: { type: Number, required: true },
     membersCount: { type: Number, required: true },
+    profileUrl: { type: String, default: '#' },
     imageUrl: { type: String, required: true },
     rank: { type: Number, required: true, default: 0 },
   },
@@ -63,9 +76,9 @@ export default {
   @apply text-sm font-semibold lg:text-lg;
 }
 
-.user-name {
+.username-container {
   font-family: 'IBM Mono';
-  @apply text-xs lg:text-sm font-light;
+  @apply flex text-xs lg:text-sm font-light items-center pb-2;
 }
 
 .has-border {

--- a/components/Organizations.vue
+++ b/components/Organizations.vue
@@ -18,6 +18,7 @@
           :repositories-stars="org.repositories_stars_count"
           :repositories-number="org.repositories_count"
           :members-count="org.members_count"
+          :profile-url="org.profile_url"
           :rank="org.currentRank"
         />
       </div>


### PR DESCRIPTION
Add a new prop that utilizes the `github_profile_url` property from the organizations URL 

[Contributions API organizations model](https://github.com/jordanopensource/contributions-api/blob/e205b9b968f5b8bf16cda1f7c5bc94b3909ebb2d/models/organization.js#L26)

___

**Note**: This requires some changes to the response of the organizations on the API side since the `github_profile_url` property isn't being returned in the current implementation.

[Current implementation shows that `profile_url` isn't being added](https://github.com/jordanopensource/contributions-api/blob/a3bede5454163614878300551b3165e951c60abc/routes/Organizations.js#L86) compared to the [users response](https://github.com/jordanopensource/contributions-api/blob/e205b9b968f5b8bf16cda1f7c5bc94b3909ebb2d/routes/Users.js#L149C25-L149C43)

___

The current fix doesn't introduce any new bugs or features. It is a patch that prepares the UI to display the data once the fix mentioned in the note for the API is implemented.